### PR TITLE
Inverse transonic and pythran order in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ['setuptools>=40.8.0', 'wheel', 'transonic>=0.4.0', 'pythran', 'numpy']
+requires = ['setuptools>=40.8.0', 'wheel', 'numpy', 'pythran', 'transonic>=0.4.0']


### PR DESCRIPTION
I open this PR to check if the order changes anything for the CI.

It could "fix" an issue related to the fact that the lastest pythran (0.9.6)
requires gast 0.3.3 but the lastest transonic just requires "gast"
(which corresponds to gast 0.4.0).

pip is not able to correctly handle this situation.

See https://github.com/serge-sans-paille/pythran/issues/1628